### PR TITLE
Make default routes part of a blueprint and add templates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ matrix:
       env: TOXENV=py35-coverage
     - python: '3.6'
       env: TOXENV=py36-coverage
-    - python: '3.6'
-      env: TOXENV=pylama
 
 install:
   - pip install tox coveralls

--- a/example/app.py
+++ b/example/app.py
@@ -18,19 +18,29 @@ class Error(Exception):
 
 # More complicated example:
 
-# Initialize flask by ourselves.
-app = flask.Flask(__name__)
+gourde = Gourde(__name__)
+app = gourde.app
 
 
-# This needs to go first to have priority over
-# the default routes.
-@app.route('/example')
+# Override the default index
+@app.route('/')
 def index():
-    return 'Example'
+    return flask.render_template('index.html')
 
 
-# Setup our wrapper.
-gourde = Gourde(app)
+# Add a new page.
+@app.route('/example')
+def example():
+    return flask.render_template('example.html')
+
+
+# Create a custom health check callbback.
+def is_healthy():
+    """Custom "health" check."""
+    import random
+    if random.random() > 0.5:
+        raise Error()
+    return True
 
 
 def main():
@@ -42,15 +52,8 @@ def main():
     # Setup gourde with the args.
     gourde.setup(args)
 
-    def _is_healthy():
-        """Custom "health" check."""
-        import random
-        if random.random() > 0.5:
-            raise Error()
-        return True
-
     # Register a custom health check.
-    gourde.is_healthy = _is_healthy
+    gourde.is_healthy = is_healthy
 
     # Start the application.
     gourde.run()

--- a/example/app_test.py
+++ b/example/app_test.py
@@ -3,12 +3,29 @@ from example import app
 
 
 class AppTest(unittest.TestCase):
-
     """Very basic tests."""
 
-    def test_app(self):
-        self.assertIsNotNone(app.app)
-        # TODO: start main and send a SIGKILL from a thread.
+    def setUp(self):
+        app.gourde.setup()  # This is unfortunately still necessary.
+        self.app = app.app.test_client()
+
+    def test_views(self):
+        rv = self.app.get('/')
+        self.assertEqual(rv.status_code, 200)
+
+        rv = self.app.get('/example')
+        self.assertEqual(rv.status_code, 200)
+
+    def test_gourde_views(self):
+        """Test generic views, just for fun."""
+        rv = self.app.get('/-/')
+        self.assertEqual(rv.status_code, 200)
+
+        rv = self.app.get('/-/threads')
+        self.assertEqual(rv.status_code, 200)
+
+        rv = self.app.get('/-/ready')
+        self.assertEqual(rv.status_code, 200)
 
 
 if __name__ == '__main__':

--- a/example/app_test.py
+++ b/example/app_test.py
@@ -1,4 +1,6 @@
 import unittest
+
+from gourde import testutils
 from example import app
 
 
@@ -6,7 +8,7 @@ class AppTest(unittest.TestCase):
     """Very basic tests."""
 
     def setUp(self):
-        app.gourde.setup()  # This is unfortunately still necessary.
+        testutils.setup(app.gourde)
         self.app = app.app.test_client()
 
     def test_views(self):

--- a/example/templates/example.html
+++ b/example/templates/example.html
@@ -1,0 +1,8 @@
+{% extends "gourde/_base.html" %}
+
+{% block title %}Example{% endblock %}
+
+{% block content %}
+    <h1>Example</h1>
+    <pre>Blip blop</pre>
+{% endblock %}

--- a/example/templates/index.html
+++ b/example/templates/index.html
@@ -1,0 +1,12 @@
+{# Extend gourde/_base.html to have some default goodies. #}
+{% extends "gourde/_base.html" %}
+
+{% block title %}Home{% endblock %}
+
+{% block content %}
+    <h1>Home</h1>
+    <div class="progress">
+        <div class="progress-bar progress-bar-striped progress-bar-animated" role="progressbar" aria-valuenow="75"
+             aria-valuemin="0" aria-valuemax="100" style="width: 75%"></div>
+    </div>
+{% endblock %}

--- a/gourde/gourde.py
+++ b/gourde/gourde.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+"""Microframework for Flask."""
 
 import argparse
 import flask

--- a/gourde/gourde_test.py
+++ b/gourde/gourde_test.py
@@ -2,24 +2,22 @@
 import unittest
 import flask
 import prometheus_client
+
 import gourde
+from gourde import testutils
 
 
 class GourdeTest(unittest.TestCase):
 
     def setUp(self):
-        # Make sure we don't use sys.argv
-        parser = gourde.Gourde.get_argparser()
-        self.args = parser.parse_args([])
-
         # Don't use a shared registry.
         self.registry = prometheus_client.CollectorRegistry(auto_describe=True)
 
     def test_basic(self):
         """Create a gourde from a name."""
         g = gourde.Gourde(__name__, registry=self.registry)
+        testutils.setup(g)
         g.setup()
-        g.setup(self.args)
         self.assertIsNotNone(g)
         self.assertTrue(g.is_healthy())
         self.assertTrue(g.is_ready())
@@ -29,7 +27,7 @@ class GourdeTest(unittest.TestCase):
         """Create a gourde with a flask."""
         app = flask.Flask(__name__)
         g = gourde.Gourde(app, registry=self.registry)
-        g.setup(self.args)
+        testutils.setup(g)
         self.assertIsNotNone(g)
 
     # TODO:

--- a/gourde/templates/gourde/_base.html
+++ b/gourde/templates/gourde/_base.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
+    <title>{% block title %}{{ gourde.name }}{% endblock %}</title>
+
+    <!-- Bootstrap -->
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.0/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootswatch/4.1.0/lumen/bootstrap.min.css">
+
+    <!-- Font awesome -->
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
+
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+    <a class="navbar-brand" href="#">{{ gourde.name }}</a>
+    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarColor01"
+            aria-controls="navbarColor01" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+    </button>
+
+    <div class="collapse navbar-collapse">
+        <ul class="nav navbar-nav mr-auto">
+            {# Add a way to add links here. #}
+        </ul>
+        <ul class="nav navbar-nav ml-auto">
+
+            {# Add a way to add links here #}
+        </ul>
+    </div>
+</nav>
+
+
+<div class="container">
+    {% block content %}
+    {% endblock %}
+</div>
+<!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
+<script src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
+<!-- Bootstrap -->
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.0/js/bootstrap.min.js"></script>
+</body>
+</html>

--- a/gourde/templates/gourde/status.html
+++ b/gourde/templates/gourde/status.html
@@ -1,0 +1,14 @@
+{% extends "gourde/_base.html" %}
+
+{% block title %}{{ gourde.name }}{% endblock %}
+
+{% block content %}
+    <h1>{{ gourde.name }}</h1>
+{% if gourde.debug %}
+<pre>{{ app }}</pre>
+
+<pre>{{ config }}</pre>
+
+<pre>{{ request }}</pre>
+{% endif %}
+{% endblock %}

--- a/gourde/templates/gourde/threads.html
+++ b/gourde/templates/gourde/threads.html
@@ -1,0 +1,17 @@
+{% extends "gourde/_base.html" %}
+
+{% block title %}threads{% endblock %}
+
+{% block content %}
+    <h1>Threads</h1>
+    <div class="row">
+        {% for thread, stack in threads.items() %}
+            <div class="card">
+                <h3 class="card-header">{{ thread }}</h3>
+                <div class="card-body">
+                    <pre>{{ stack }}</pre>
+                </div>
+            </div>
+        {% endfor %}
+    </div>
+{% endblock %}

--- a/gourde/testutils.py
+++ b/gourde/testutils.py
@@ -1,0 +1,11 @@
+"""Test utils for gourde."""
+
+
+def setup(gourde, args=None):
+    """Setup gourde for testing."""
+    args = args or []
+    parser = gourde.get_argparser()
+    # Make sure we don't use sys.argv.
+    args = parser.parse_args(args)
+    # Setup everything.
+    gourde.setup(args)

--- a/pylama.ini
+++ b/pylama.ini
@@ -12,7 +12,7 @@
 # D102: Missing docstring in public method
 # D103: Missing docstring in public function
 # D104: Missing docstring in public package
-skip={toxworkdir}/*,build/*,.tox/*,env/*,bom/*,venv/*
+skip={toxworkdir}/*,build/*,.tox/*,env/*,bom/*,venv/*,setup.py
 ignore=D105,D203,D213,D100,D101,D102,D103,D104
 
 [pylama:pycodestyle]

--- a/tox.ini
+++ b/tox.ini
@@ -4,15 +4,12 @@ envlist = {py35,py36}-coverage,pylama
 [testenv]
 commands =
     coverage erase
-    coverage run -m pytest
+    coverage run -m pytest --pylama
     coverage report
     coverage xml -o coverage-{envname}.xml
 deps =
     pytest
+    pylama
     coverage
     -rrequirements.txt
     -rtests-requirements.txt
-
-[testenv:pylama]
-commands = pylama gourde example
-deps = pylama


### PR DESCRIPTION
* Add templates
* Make gourdes url a blueprint (with `/-/` url prefix)
* Redirect `/` to `/-/` by default, but easy to override
* Add `/-/threads` to display backtraces
* Better example, more tests.