### PR TITLE
[Breaking] Add gunicorn support & make twisted optionnal

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,16 +5,26 @@
 [![PyPI version](https://badge.fury.io/py/gourde.svg)](https://badge.fury.io/py/gourde)
 [![Supported Python versions](https://img.shields.io/pypi/pyversions/gourde.svg)](https://pypi.python.org/pypi/gourde/)
 
-Flask(-Twisted) microframework for microservices with Prometheus and Sentry support.
+Flask(-Twisted/Gunicorn) microframework for microservices with Prometheus and Sentry support.
 
 The goal is to remove most of the boilerplate necessary to start a simple HTTP application.
 This provides:
 
 * Sane arguments (`--host`, `--port`, `--debug`, `--log-level`)
-* Twisted support to have a production ready uwsgi container (`gourde.twisted`, `--twisted`)
+* Support to have a production ready uwsgi container (`--twisted` or `--gunicorn`)
 * Prometheus support with default metrics (`gourde.metrics`: See [prometheus_flask_exporter](https://github.com/rycus86/prometheus_flask_exporter))
 * Optional sentry support if the `SENTRY_DSN` env var is set.
 * If you have a 'static' directory in your module, just put a favicon.ico inside!
+
+## Installation
+
+```bash
+pip install gourde
+
+# To use a production ready wsgi server install one of the following extra requirements
+pip install gourde[twisted]
+pip install gourde[gunicorn]
+```
 
 ## Quick-start
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,9 +6,5 @@ prometheus-flask-exporter
 blinker
 raven
 
-# To get a real wsgi container.
-flask-twisted
-twisted
-
 # For APIs (optional)
 # flask_restplus

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,10 @@ setuptools.setup(
     version='0.2.1',
     include_package_data=True,
     install_requires=_INSTALL_REQUIRES,
+    extras_require={
+        'twisted': ['flask-twisted', 'twisted'],
+        'gunicorn': ['gunicorn'],
+    },
     dependency_links=_DEPENDENCY_LINKS,
     tests_require=_TEST_REQUIRE,
     entry_points={
@@ -50,7 +54,7 @@ setuptools.setup(
     author_email="c.chary@criteo.com",
     description="Flask(-Twisted) microframework for microservices with Prometheus and Sentry support.",
     license="Apache 2",
-    keywords="flask twisted microframework microservice prometheus sentry",
+    keywords="flask twisted gunicorn microframework microservice prometheus sentry",
     url="https://github.com/criteo/gourde/",
     project_urls={
         "Source Code": "https://github.com/criteo/gourde/",


### PR DESCRIPTION
For compatibility, clients need to change their imports
from 'pip install gourde'
to 'pip install gourde[twisted]'