### PR TITLE
Revert "Explicitly use encoding when reading README"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ try:
     readme = parse_from_file(readme_file)
 except ImportError:
     # m2r may not be installed in user environment
-    with open(readme_file, encoding='utf-8') as f:
+    with open(readme_file) as f:
         readme = f.read()
 
 


### PR DESCRIPTION
This reverts commit f25ca8bbfda2ecc1220484140b8f9975d0afc188.
This is done to maintain python 2.x compatibility
Signed-off-by: Jean-Francois Weber-Marx <jfwm@hotmail.com>