### PR TITLE
Default to group_by endpoint for http metrics

### DIFF
--- a/gourde/gourde.py
+++ b/gourde/gourde.py
@@ -171,6 +171,10 @@ class Gourde(object):
 
     def setup_prometheus(self, registry=None, **kwargs):
         """Setup Prometheus."""
+
+        if "group_by" not in kwargs:
+            kwargs["group_by"] = "endpoint"
+
         if registry:
             kwargs["registry"] = registry
         self.metrics = PrometheusMetrics(self.app, **kwargs)


### PR DESCRIPTION
This should avoid the number of metrics bloating too much if there's
security scan on the app