### PR TITLE
Do not rely on gunicorn for six import

### DIFF
--- a/gourde/gourde.py
+++ b/gourde/gourde.py
@@ -309,8 +309,8 @@ class Gourde(object):
     def run_with_gunicorn(self, **options):
         """Run with gunicorn."""
         import gunicorn.app.base
-        from gunicorn.six import iteritems
         import multiprocessing
+        from six import iteritems
 
         class GourdeApplication(gunicorn.app.base.BaseApplication):
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 Flask
 prometheus_client
 prometheus-flask-exporter
+six
 
 # For exception handling.
 blinker

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py35,py36,py37}-coverage,pylama
+envlist = py{27,35,36,37}-coverage,pylama
 
 [testenv]
 commands =


### PR DESCRIPTION
gunicorn.six is no longer valid with new gunicorn release 20.0.x