### PR TITLE
[Impacting] metrics: Reduce the cardinality of metrics by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ htmlcov/
 .cache
 nosetests.xml
 coverage.xml
+coverage-pylama.xml
 *-coverage.xml
 *,cover
 .hypothesis/


### PR DESCRIPTION
Currently metrics are returned for each path:
* /some/1/detail
* /some/2/detail
* etc.

This will change metrics to be pattern based:
* /some/<some_id>/detail

This will significantly reduce the amount of metrics produced by default and allow for useful metric monitoring.